### PR TITLE
Fix #2: Use new v8 GetBackingStore() API when supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [ "Andras", "quick", "fast", "getrusage", "cpu", "memory", "resources", "used" ],
 
   "dependencies": {
-    "nan": "2.14.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "qnit": "^0.25"

--- a/qrusage.cc
+++ b/qrusage.cc
@@ -22,7 +22,13 @@ double * getFloat64ArrayPointer( unsigned int length, v8::Local<v8::Value> arg )
         v8::Local<v8::Float64Array> array = arg.As<v8::Float64Array>();
         if (array->Length() >= length) {
             v8::Local<v8::ArrayBuffer> ab = array->Buffer();
+// Actually it's 7.9 here but this would lead to ABI issues with Node.js 13
+// using 7.8 till 13.2.0.
+#if (V8_MAJOR_VERSION >= 8)
+            double* fields = static_cast<double*>(ab->GetBackingStore()->Data());
+#else
             double* fields = static_cast<double*>(ab->GetContents().Data());
+#endif
             return fields;
         }
     }


### PR DESCRIPTION
Fixes issue #2 

 - check for `V8_MAJOR_VERSION >= 8`, and use new `GetBackingStore()` API if so

 - See nodejs/nan#888 for more details

 - Relax dependency on nan `~2.14` so this can build on modern Node.js versions with `nan >= 2.14.1`